### PR TITLE
feat: equalHeight props

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ export interface Props {
   // Optional gap between items, both horizontally and vertically.
   // Defaults to 32px.
   gap?: number;
+  
+  // Optional. Equalize the height of items on each row.
+  equalHeight?: boolean;
 
   // An array of items to render in the masonry layout. Each item
   // should be an object a unique key and a node (React component).

--- a/src/__stories__/index.stories.tsx
+++ b/src/__stories__/index.stories.tsx
@@ -84,7 +84,8 @@ function Box(props: { id: number; overflowComponent?: boolean }) {
         lineHeight: "24px",
         padding: "24px",
         position: "relative",
-        width: "100%"
+        width: "100%",
+        height: "100%",
       }}
     >
       <p>

--- a/src/__stories__/index.stories.tsx
+++ b/src/__stories__/index.stories.tsx
@@ -13,6 +13,9 @@ storiesOf("Masonry", module)
       </div>
     );
   })
+  .add("Equal Height", () => {
+    return <Masonry minColumnWidth={200} equalHeight items={generateItems(50)} />;
+  })
   .add("Custom gap", () => {
     return <Masonry gap={96} minColumnWidth={200} items={generateItems(50)} />;
   })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,9 @@ export interface Props {
   // Pass this through for server-side rendering support.
   containerWidth?: number;
 
+  // Optional. Equalize the height of items on each row.
+  equalHeight?: boolean;
+
   // Optional gap between items, both horizontally and vertically.
   // Defaults to 32px.
   gap?: number;
@@ -38,7 +41,7 @@ export class Masonry extends React.PureComponent<Props, State> {
   };
 
   public render() {
-    const { gap = DEFAULT_GAP, items, minColumnWidth } = this.props;
+    const { gap = DEFAULT_GAP, items, minColumnWidth,equalHeight } = this.props;
     const { containerWidth } = this.state;
     const margin = gap / 2;
     const count = containerWidth !== undefined ? columnCount(containerWidth, gap, minColumnWidth) : null;
@@ -47,7 +50,17 @@ export class Masonry extends React.PureComponent<Props, State> {
     if (count !== null && items.length > 0) {
       const columns = sort(count, items);
 
-      content = (
+      content = equalHeight ? (
+          <div style={{display: "flex", margin: -margin, justifyContent: "space-between", flexWrap: "wrap"}}>
+              {columns.map((c) => (
+                  c.map(i => (
+                      <div key={i.key} style={{padding: margin, width: `${100 / columns.length}%`}}>
+                          {i.node}
+                      </div>
+                  ))
+              ))}
+          </div>
+      ) : (
         <div style={{ display: "flex", margin: -margin }}>
           {columns.map((c, i) => (
             <div key={i} style={{ flex: "1 1 auto", width: `${100 / columns.length}%` }}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,7 +51,7 @@ export class Masonry extends React.PureComponent<Props, State> {
       const columns = sort(count, items);
 
       content = equalHeight ? (
-          <div style={{display: "flex", margin: -margin, justifyContent: "space-between", flexWrap: "wrap"}}>
+          <div style={{display: "flex", margin: -margin, flexWrap: "wrap"}}>
               {columns.map((c) => (
                   c.map(i => (
                       <div key={i.key} style={{padding: margin, width: `${100 / columns.length}%`}}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ export class Masonry extends React.PureComponent<Props, State> {
   };
 
   public render() {
-    const { gap = DEFAULT_GAP, items, minColumnWidth,equalHeight } = this.props;
+    const { gap = DEFAULT_GAP, items, minColumnWidth, equalHeight } = this.props;
     const { containerWidth } = this.state;
     const margin = gap / 2;
     const count = containerWidth !== undefined ? columnCount(containerWidth, gap, minColumnWidth) : null;


### PR DESCRIPTION
I only added `equalHeight` prop that equalises the height of items. One of the big points that convinced me to use `react-masonry-responsive` is that helps me to easily handle a bunch of cards without concern of Responsive issues. For me, this feature was so useful.